### PR TITLE
Android10で写真をアップロードできないのを修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,10 +4,11 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@drawable/app_icon"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/encount/UserPost.kt
+++ b/app/src/main/java/com/example/encount/UserPost.kt
@@ -309,7 +309,8 @@ class UserPost : AppCompatActivity() {
             val url = "https://kinako.cf/encount/PostPhoto.php"
 
             //パスを設定
-            var pass = "/sdcard/Pictures/"
+            //var pass = "/sdcard/Pictures/"
+            var pass = "/storage/emulated/0/Pictures/"
             //ファイル名を取得
             pass = pass + uurl
             //写真のパスを取得する


### PR DESCRIPTION
●原因●
　Android10からパーミッションの仕様が変更され、従来のようにファイルにアクセスできない場合がある。
　そのため、応急的にManifestへ下記の一行を記入することで、この問題を回避できた
　android:requestLegacyExternalStorage="true"